### PR TITLE
made hola an executable, changed to bundle template, added README, merged in dutch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+*.gem
+*.rbc
+.bundle
+.config
+.yardoc
+Gemfile.lock
+InstalledFiles
+_yardoc
+coverage
+doc/
+lib/bundler/man
+pkg
+rdoc
+spec/reports
+test/tmp
+test/version_tmp
+tmp

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 1.8.7
+  - ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,11 @@ rvm:
   - 1.8.7
   - 1.9.3
   - 2.0.0
+  - 2.1.6
+  - 2.2.2
+before_install:
+  - gem update --system $RUBYGEMS_VERSION
+  - gem --version
+  - gem install bundler
+  - bundle --version
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: ruby
+notifications:
+  email:
+    on_success: change
+    on_failure: always
 rvm:
   - 1.9.3
   - 1.8.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ notifications:
 rvm:
   - 1.9.3
   - 1.8.7
+  - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ notifications:
     on_success: change
     on_failure: always
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,3 @@ notifications:
 rvm:
   - 1.9.3
   - 1.8.7
-  - ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ notifications:
     on_success: change
     on_failure: always
 rvm:
-  - 1.9.3
   - 1.8.7
+  - 1.9.3
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.0.0
   - 2.1.6
   - 2.2.2
+  - 2.3.1
 before_install:
   - gem update --system $RUBYGEMS_VERSION
   - gem --version

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in hola.gemspec
+gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in hola.gemspec
 gemspec
+
+gem "coveralls", :require => false, :group => :development

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,7 @@ platforms :ruby_18 do
   # mime-types 2.0 requires Ruby version >= 1.9.2
   gem "mime-types", "< 2.0"
 end
+platforms :ruby_22 do
+  gem 'test-unit'
+end
 gem "coveralls", :require => false, :group => :development

--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,4 @@ platforms :ruby_22, :ruby_23 do
   gem 'minitest'
 end
 gem 'coveralls', :require => false, :group => :development
+gem 'tins', '<1.7.0' if RUBY_VERSION =~ /^1\./

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,8 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in hola.gemspec
 gemspec
 
+platforms :ruby_18 do
+  # mime-types 2.0 requires Ruby version >= 1.9.2
+  gem "mime-types", "< 2.0"
+end
 gem "coveralls", :require => false, :group => :development

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,8 @@ platforms :ruby_18, :ruby_19 do
   # json 2.0.1 requires Ruby >= 2.0
   gem 'json', '< 2.0'
 end
-platforms :ruby_20 do
+platforms :ruby_22, :ruby_23 do
   gem 'test-unit'
+  gem 'minitest'
 end
 gem 'coveralls', :require => false, :group => :development

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,13 @@ gemspec
 
 platforms :ruby_18 do
   # mime-types 2.0 requires Ruby version >= 1.9.2
-  gem "mime-types", "< 2.0"
+  gem 'mime-types', '< 2.0'
 end
-platforms :ruby_22 do
+platforms :ruby_18, :ruby_19 do
+  # json 2.0.1 requires Ruby >= 2.0
+  gem 'json', '< 2.0'
+end
+platforms :ruby_20 do
   gem 'test-unit'
 end
-gem "coveralls", :require => false, :group => :development
+gem 'coveralls', :require => false, :group => :development

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,33 @@
+No copyright clause was included with code on github.
+
+Note https://help.github.com/articles/github-terms-of-service clause F.1 states:
+
+We claim no intellectual property rights over the material you provide to the Service.
+Your profile and materials uploaded remain yours.
+However, by setting your pages to be viewed publicly, you agree to allow others to view your Content.
+By setting your repositories to be viewed publicly, you agree to allow others to view and fork your repositories.
+
+Bundle supplied the following suggested license:
+
+Copyright (c) 2013 Nick Quaranto
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -7,9 +7,7 @@ Your profile and materials uploaded remain yours.
 However, by setting your pages to be viewed publicly, you agree to allow others to view your Content.
 By setting your repositories to be viewed publicly, you agree to allow others to view and fork your repositories.
 
-Bundle supplied the following suggested license:
-
-Copyright (c) 2013 Nick Quaranto
+Code supplied by Ian Heggie is Copyright (C) 2014 Ian Heggie under MIT LICENCE
 
 MIT License
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Hola
 
-Simple “hello world” gem, with tests and code coverage
+Expanded “hello world” gem, with tests and code coverage
 
-[![Travis CI tests](https://travis-ci.org/ianheggie/hola.png)](https://travis-ci.org/ianheggie/hola)
-[![Coverage Status](https://coveralls.io/repos/ianheggie/hola/badge.png)](https://coveralls.io/r/ianheggie/hola)
+[![Travis CI tests](https://travis-ci.org/ianheggie/hola-ianh.png)](https://travis-ci.org/ianheggie/hola-ianh)
+[![Coverage Status](https://coveralls.io/repos/ianheggie/hola-ianh/badge.png)](https://coveralls.io/r/ianheggie/hola-ianh)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Hola
 
-Simple “hello world” gem
+Simple “hello world” gem, with tests and code coverage
+
+[![Travis CI tests](https://travis-ci.org/ianheggie/inteltech_sms.png)](https://travis-ci.org/ianheggie/inteltech_sms)
+[![Coverage Status](https://coveralls.io/repos/ianheggie/hola/badge.png)](https://coveralls.io/r/ianheggie/hola)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Simple “hello world” gem, with tests and code coverage
 
-[![Travis CI tests](https://travis-ci.org/ianheggie/inteltech_sms.png)](https://travis-ci.org/ianheggie/inteltech_sms)
+[![Travis CI tests](https://travis-ci.org/ianheggie/hola.png)](https://travis-ci.org/ianheggie/hola)
 [![Coverage Status](https://coveralls.io/repos/ianheggie/hola/badge.png)](https://coveralls.io/r/ianheggie/hola)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Hola
+
+Simple “hello world” gem
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+    gem 'hola'
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install hola
+
+## Usage
+
+See http://guides.rubygems.org/make-your-own-gem/
+
+## Contributing
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request
+

--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@ See http://guides.rubygems.org/make-your-own-gem/
 ## Thanks
 
 Forked with thanks to qrush from https://github.com/qrush/hola.
+Thanks for contributions of extra languages from various people.

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+require "bundler/gem_tasks"
+
 require 'rake/testtask'
 
 Rake::TestTask.new do |t|

--- a/hola.gemspec
+++ b/hola.gemspec
@@ -4,24 +4,24 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'hola/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "hola"
+  spec.name          = 'hola-ianh'
   spec.version       = Hola::VERSION
-  spec.authors       = ["Nick Quaranto"]
-  spec.email         = %q{nick@quaran.to}
-  spec.description   = %q{A simple hello world gem}
+  spec.authors       = ['Nick Quaranto', 'Ian Heggie']
+  spec.email         = %q{nick@quaran.to ian@heggie.biz}
+  spec.description   = %q{An expanded example of a simple hello world gem}
   spec.summary       = %q{Hola!}
-  spec.homepage      = %q{http://rubygems.org/gems/hola}
-  spec.license       = "UNKNOWN"
+  spec.homepage      = %q{http://rubygems.org/gems/hola-ianh}
+  spec.license       = 'UNKNOWN+MIT'
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'rake'
 
-  spec.required_rubygems_version = Gem::Requirement.new(">= 0") if spec.respond_to? :required_rubygems_version=
+  spec.required_rubygems_version = Gem::Requirement.new('>= 0') if spec.respond_to? :required_rubygems_version=
   if spec.respond_to? :specification_version then
     spec.specification_version = 3
 

--- a/hola.gemspec
+++ b/hola.gemspec
@@ -1,23 +1,29 @@
-Gem::Specification.new do |s|
-  s.name               = "hola"
-  s.version            = "0.0.3"
-  s.default_executable = "hola"
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'hola/version'
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Nick Quaranto"]
-  s.date = %q{2010-04-03}
-  s.description = %q{A simple hello world gem}
-  s.email = %q{nick@quaran.to}
-  s.files = ["Rakefile", "lib/hola.rb", "lib/hola/translator.rb", "bin/hola"]
-  s.test_files = ["test/test_hola.rb"]
-  s.homepage = %q{http://rubygems.org/gems/hola}
-  s.require_paths = ["lib"]
-  s.rubygems_version = %q{1.6.2}
-  s.summary = %q{Hola!}
-  s.executables << %q{hola}
+Gem::Specification.new do |spec|
+  spec.name          = "hola"
+  spec.version       = Hola::VERSION
+  spec.authors       = ["Nick Quaranto"]
+  spec.email         = %q{nick@quaran.to}
+  spec.description   = %q{A simple hello world gem}
+  spec.summary       = %q{Hola!}
+  spec.homepage      = %q{http://rubygems.org/gems/hola}
+  spec.license       = "UNKNOWN"
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 3
+  spec.files         = `git ls-files`.split($/)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "rake"
+
+  spec.required_rubygems_version = Gem::Requirement.new(">= 0") if spec.respond_to? :required_rubygems_version=
+  if spec.respond_to? :specification_version then
+    spec.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
     else
@@ -25,4 +31,3 @@ Gem::Specification.new do |s|
   else
   end
 end
-

--- a/hola.gemspec
+++ b/hola.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name               = "hola"
-  s.version            = "0.0.1"
+  s.version            = "0.0.2"
   s.default_executable = "hola"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=

--- a/hola.gemspec
+++ b/hola.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name               = "hola"
-  s.version            = "0.0.1"
+  s.version            = "0.0.3"
   s.default_executable = "hola"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.6.2}
   s.summary = %q{Hola!}
+  s.executables << %q{hola}
 
   if s.respond_to? :specification_version then
     s.specification_version = 3

--- a/lib/hola.rb
+++ b/lib/hola.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 class Hola
   def self.hi(language)
     translator = Translator.new(language)

--- a/lib/hola.rb
+++ b/lib/hola.rb
@@ -6,3 +6,4 @@ class Hola
 end
 
 require 'hola/translator'
+require 'hola/version'

--- a/lib/hola/translator.rb
+++ b/lib/hola/translator.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 class Hola::Translator
   def initialize(language = "english")
     @language = language
@@ -9,6 +11,8 @@ class Hola::Translator
       "hola mundo"
     when "korean"
       "anyoung ha se yo"
+    when "polish"
+      "witaj świecie"
     else
       "hello world"
     end

--- a/lib/hola/translator.rb
+++ b/lib/hola/translator.rb
@@ -9,6 +9,8 @@ class Hola::Translator
       "hola mundo"
     when "korean"
       "anyoung ha se yo"
+    when "dutch"
+      "hallo wereld"
     else
       "hello world"
     end

--- a/lib/hola/translator.rb
+++ b/lib/hola/translator.rb
@@ -9,6 +9,8 @@ class Hola::Translator
       "hola mundo"
     when "korean"
       "anyoung ha se yo"
+    when "german"
+      "hallo welt"
     else
       "hello world"
     end

--- a/lib/hola/translator.rb
+++ b/lib/hola/translator.rb
@@ -11,6 +11,8 @@ class Hola::Translator
       "anyoung ha se yo"
     when "german"
       "hallo welt"
+    when "brazilian portuguese"
+      "olá mundo"
     else
       "hello world"
     end

--- a/lib/hola/version.rb
+++ b/lib/hola/version.rb
@@ -1,3 +1,3 @@
 class Hola
-  VERSION = '0.0.4'
+  VERSION = '0.1.0'
 end

--- a/lib/hola/version.rb
+++ b/lib/hola/version.rb
@@ -1,0 +1,3 @@
+module Hola
+  VERSION = "0.0.3"
+end

--- a/lib/hola/version.rb
+++ b/lib/hola/version.rb
@@ -1,3 +1,3 @@
-module Hola
+class Hola
   VERSION = "0.0.3"
 end

--- a/lib/hola/version.rb
+++ b/lib/hola/version.rb
@@ -1,3 +1,3 @@
 class Hola
-  VERSION = "0.0.3"
+  VERSION = '0.0.4'
 end

--- a/test/test_hola.rb
+++ b/test/test_hola.rb
@@ -1,3 +1,6 @@
+require 'coveralls'
+Coveralls.wear!
+
 require 'test/unit'
 require 'hola'
 

--- a/test/test_hola.rb
+++ b/test/test_hola.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require 'test/unit'
 require 'hola'
 
@@ -12,5 +14,9 @@ class HolaTest < Test::Unit::TestCase
 
   def test_spanish_hello
     assert_equal "hola mundo", Hola.hi("spanish")
+  end
+  
+  def test_polish_hello
+    assert_equal "witaj świecie", Hola.hi("spanish")
   end
 end

--- a/test/test_hola.rb
+++ b/test/test_hola.rb
@@ -13,4 +13,8 @@ class HolaTest < Test::Unit::TestCase
   def test_spanish_hello
     assert_equal "hola mundo", Hola.hi("spanish")
   end
+
+  def test_dutch_hello
+    assert_equal "hallo wereld", Hola.hi("dutch")
+  end
 end

--- a/test/test_hola.rb
+++ b/test/test_hola.rb
@@ -13,4 +13,8 @@ class HolaTest < Test::Unit::TestCase
   def test_spanish_hello
     assert_equal "hola mundo", Hola.hi("spanish")
   end
+
+  def test_german_hello
+    assert_equal "hallo welt", Hola.hi("german")
+  end
 end

--- a/test/test_hola.rb
+++ b/test/test_hola.rb
@@ -17,4 +17,8 @@ class HolaTest < Test::Unit::TestCase
   def test_german_hello
     assert_equal "hallo welt", Hola.hi("german")
   end
+
+  def test_brazilian_portuguese_hello
+    assert_equal "olá mundo", Hola.hi("brazilian portuguese")
+  end
 end

--- a/test/test_hola.rb
+++ b/test/test_hola.rb
@@ -17,6 +17,6 @@ class HolaTest < Test::Unit::TestCase
   end
   
   def test_polish_hello
-    assert_equal "witaj świecie", Hola.hi("spanish")
+    assert_equal "witaj świecie", Hola.hi("polish")
   end
 end

--- a/test/test_hola.rb
+++ b/test/test_hola.rb
@@ -13,4 +13,8 @@ class HolaTest < Test::Unit::TestCase
   def test_spanish_hello
     assert_equal "hola mundo", Hola.hi("spanish")
   end
+  
+  def test_korean_hello
+    assert_equal "anyoung ha se yo", Hola.hi("korean")
+  end
 end


### PR DESCRIPTION
Hi, When I went to use hola to test a patch to my rbenv-binstubs project, I noticed 'hola' was not installed as an executable. So I did it (plus a bit extra):
- made hola an executable in gemspec (so bundle --binstubs creates bin/hola)
- used bundle template (makes it simple to build and publish gem)
- made VERSION a class variable
- Added a README.md and LICENSE.txt file
- Added .travis.yml as an example for automated CI testing
